### PR TITLE
Add the new Floodlight Cam Wired Pro in FLOODLIGHT_CAM_KINDS

### DIFF
--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -77,7 +77,7 @@ DOORBELL_PRO_KINDS = ["lpd_v1", "lpd_v2", "lpd_v4"]
 DOORBELL_ELITE_KINDS = ["jbox_v1"]
 PEEPHOLE_CAM_KINDS = ["doorbell_portal"]
 
-FLOODLIGHT_CAM_KINDS = ["hp_cam_v1", "floodlight_v2", "cocoa_floodlight"]
+FLOODLIGHT_CAM_KINDS = ["hp_cam_v1", "floodlight_v2", "cocoa_floodlight", "floodlight_pro"]
 INDOOR_CAM_KINDS = ["stickup_cam_mini"]
 SPOTLIGHT_CAM_BATTERY_KINDS = ["stickup_cam_v4"]
 SPOTLIGHT_CAM_WIRED_KINDS = ["hp_cam_v2", "spotlightw_v2"]


### PR DESCRIPTION
This is the camera in question -> https://en-uk.ring.com/products/floodlight-cam-wired-pro

Change required to enable light control in HomeAssistant